### PR TITLE
import of travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+language: python
+python:
+# - 2.6
+ - 2.7
+
+env:
+  global:
+    - PATH=$HOME/miniconda/bin:$HOME/miniconda/envs/ci/bin/:$PATH
+    - common_py_deps="pip nose cython"
+  matrix:
+    - deps="scipy=0.11 numpy=1.7"
+# - deps="numpy=0.12 numpy=1.8" 
+# - deps="numpy=0.13 numpy=1.8" 
+# - deps="numpy=0.14 numpy=1.9" 
+# - deps="scipy=0.11 numpy=1.6"
+
+before_install:
+- deactivate # travis python venv
+- wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O mc.sh -o /dev/null
+- bash mc.sh -b
+- conda create -q --yes -n ci python=$TRAVIS_PYTHON_VERSION $deps $common_py_deps
+- source activate ci
+- python -c "import scipy; print scipy.__version__; print scipy.__numpy_version__"
+- conda list
+
+install:
+- python setup.py install
+
+script:
+- python setup.py test 
+
+#after_success:
+#- tools/ci/travis/make_docs.sh
+
+deploy:
+  edge: true # testing bleeding edge git deployment code
+  provider: pypi
+  distributions: "sdist"
+#  skip_cleanup: true
+# docs_dir is ignored by travis (despite the issue filed against this feature, maybe its not yet active?
+#  docs_dir: doc/build/html
+# TODO: security tokens are encrypted on repository base (reencrypt when moving repo to cmb organisation) 
+  user:
+    secure: "Z6h333HK9R9b4vwYzk5N54IeMJ8vmd4V+vXRTLNnOCCqVkWcocWY9HBX2s9jk3TkSJbg9eL/EVzCv7HVGY1A80czNN160Vj3z5J51WEfHk4hhC7GDSXEU1CGRdp3j+79/WeaioOstq3y4Mxy6v1Afn3k7gAY7ui+yYbSEbRIG0A="
+  password:
+    secure: "F3I26Mx0vbiIrSf/MsE8OGNV4xr82Wx4AWItHcXEq+pwBreNyCg/KVQInJ90lSh2RmvGAMmzw6rQ4EFaHYrFuAekilM/4tkRBGF/pSrEG7KSL2ysyoJIqTRncJCs1USyNYWodmXjRTQjLyJKoZufpNZ4u6Da1pVQDZqbsL0LtZo="
+  on:
+    python: 2.7 # only upload docs and sdist for py27
+    tags: true
+    # TODO: should only deploy for tagged master release as soon as stable
+    # temporary workaround for travis issue #1675
+    all_branches: true
+


### PR DESCRIPTION
merge this and reencrypt the security tokens for pypi to enable automatic sdist publishing on PyPI, if you push a new tag (release) to Github.

Encrypting is described here
http://docs.travis-ci.com/user/encryption-keys/  